### PR TITLE
fix: Improve contrast of process section cards

### DIFF
--- a/styles-v3.css
+++ b/styles-v3.css
@@ -895,7 +895,7 @@ p {
     transition: transform 0.15s ease-out;
     will-change: transform, opacity;
     backface-visibility: hidden;
-    background: var(--glass-bg);
+    background: rgba(10, 15, 41, 0.6);
     border: 1px solid var(--glass-border);
     backdrop-filter: blur(10px);
     box-shadow: var(--shadow-xl);


### PR DESCRIPTION
This commit addresses your feedback regarding the readability of the cards in the new UX process section. The background of the cards has been made darker and more opaque to provide better contrast for the text and icons.

- Modifies the `background` property for the `#process .stage-card` selector in `styles-v3.css`.
- Changes the background from a highly transparent white to a semi-transparent dark blue, which improves contrast while maintaining the glassmorphism aesthetic.